### PR TITLE
fix alignment of bankselect bits in c backbone.

### DIFF
--- a/src/util/ICM_20948_C.c
+++ b/src/util/ICM_20948_C.c
@@ -116,6 +116,7 @@ ICM_20948_Status_e	ICM_20948_i2c_master_single_r( ICM_20948_Device_t* pdev, uint
 
 ICM_20948_Status_e	ICM_20948_set_bank( ICM_20948_Device_t* pdev, uint8_t bank ){
 	if( bank > 3 ){ return ICM_20948_Stat_ParamErr; } // Only 4 possible banks
+	bank = (bank << 4) & 0x30; // bits 5:4 of REG_BANK_SEL
 	return ICM_20948_execute_w( pdev, REG_BANK_SEL, &bank, 1 );
 }
 


### PR DESCRIPTION
This fix adjusts the C backbone function that selects register banks on the IMU. The active bits are 5:4 in the IMU so the numerical choice must be shifted left 4 bits. All attempts to change the register bank in this library were non-functional due to this bug. 

I discovered it while changing the FSR of the gyro and accel and noticing that it had no impact on the output. Comparing this code to the driver I had started writing for this chip I discovered the problem.