### PR TITLE
Include RoomTemp_Offset in temperature calculation

### DIFF
--- a/src/ICM_20948.cpp
+++ b/src/ICM_20948.cpp
@@ -122,7 +122,7 @@ float ICM_20948::temp(void)
 
 float ICM_20948::getTempC(int16_t val)
 {
-    return (((float)val) / 333.87) + 21;
+    return (((float)val - 21) / 333.87) + 21;
 }
 
 const char *ICM_20948::statusString(ICM_20948_Status_e stat)


### PR DESCRIPTION
Minor update to address issue #17.

Adds RoomTemp_Offset to temperature calculation as outlined in the ICM-20948 datasheet.

**TEMP_degC = ((TEMP_OUT – RoomTemp_Offset)/Temp_Sensitivity) + 21degC**