### PR TITLE
Changes to allow the code to compile on the Arduino NANO 33 BLE

### DIFF
--- a/src/ICM_20948.cpp
+++ b/src/ICM_20948.cpp
@@ -908,7 +908,7 @@ ICM_20948_Status_e ICM_20948_write_I2C(uint8_t reg, uint8_t *data, uint32_t len,
 
     _i2c->beginTransmission(addr);
     _i2c->write(reg);
-    _i2c->write(data, len);
+    _i2c->write(data, (uint8_t)len);
     _i2c->endTransmission();
 
     // for( uint32_t indi = 0; indi < len; indi++ ){

--- a/src/ICM_20948.h
+++ b/src/ICM_20948.h
@@ -119,8 +119,8 @@ public:
 // I2C
 
 // Forward declarations of TwoWire and Wire for board/variant combinations that don't have a default 'SPI'
-class TwoWire;
-extern TwoWire Wire;
+//class TwoWire; // Commented by PaulZC 21/2/8 - this was causing compilation to fail on the Arduino NANO 33 BLE
+//extern TwoWire Wire; // Commented by PaulZC 21/2/8 - this was causing compilation to fail on the Arduino NANO 33 BLE
 
 class ICM_20948_I2C : public ICM_20948
 {
@@ -144,8 +144,8 @@ public:
 #define ICM_20948_SPI_DEFAULT_MODE SPI_MODE0
 
 // Forward declarations of SPIClass and SPI for board/variant combinations that don't have a default 'SPI'
-class SPIClass;
-extern SPIClass SPI;
+//class SPIClass; // Commented by PaulZC 21/2/8 - this was causing compilation to fail on the Arduino NANO 33 BLE
+//extern SPIClass SPI; // Commented by PaulZC 21/2/8 - this was causing compilation to fail on the Arduino NANO 33 BLE
 
 class ICM_20948_SPI : public ICM_20948
 {


### PR DESCRIPTION
I've compiled these changes for every board I have installed and they seem fine. But there may be boards out there that do need the ```extern TwoWire Wire``` and ```extern SPIClass SPI```. Backward compatibility is not 100% guaranteed!