### PR TITLE
ICM_20948_Device_t with _last_bank set to an invalid number

### DIFF
--- a/examples/PortableC/Example999_Portable/Example999_Portable.ino
+++ b/examples/PortableC/Example999_Portable/Example999_Portable.ino
@@ -72,6 +72,9 @@ void setup()
   WIRE_PORT.setClock(400000);
 #endif
 
+  // Initialize myICM
+  ICM_20948_init_struct(&myICM);
+
   // Link the serif
   ICM_20948_link_serif(&myICM, &mySerif);
 

--- a/src/ICM_20948.cpp
+++ b/src/ICM_20948.cpp
@@ -12,6 +12,7 @@ ICM_20948_Status_e ICM_20948_read_SPI(uint8_t reg, uint8_t *buff, uint32_t len, 
 // Base
 ICM_20948::ICM_20948()
 {
+  status = ICM_20948_init_struct(&_device);
 }
 
 void ICM_20948::enableDebugging(Stream &debugPort)

--- a/src/util/ICM_20948_C.c
+++ b/src/util/ICM_20948_C.c
@@ -120,6 +120,16 @@ const ICM_20948_Serif_t NullSerif = {
 // Private function prototypes
 
 // Function definitions
+ICM_20948_Status_e ICM_20948_init_struct(ICM_20948_Device_t *pdev)
+{
+  // Initialize all elements by 0 except for _last_bank
+  // Initialize _last_bank to 4 (invalid bank number)
+  // so ICM_20948_set_bank function does not skip issuing bank change operation
+  static const ICM_20948_Device_t init_device = { ._last_bank = 4 };
+  *pdev = init_device;
+  return ICM_20948_Stat_Ok;
+}
+
 ICM_20948_Status_e ICM_20948_link_serif(ICM_20948_Device_t *pdev, const ICM_20948_Serif_t *s)
 {
   if (s == NULL)

--- a/src/util/ICM_20948_C.h
+++ b/src/util/ICM_20948_C.h
@@ -184,6 +184,8 @@ extern int memcmp(const void *, const void *, size_t); // Avoid compiler warning
     uint16_t _dataIntrCtl;            // Diagnostics: record the setting of DATA_INTR_CTL
   } ICM_20948_Device_t;               // Definition of device struct type
 
+  ICM_20948_Status_e ICM_20948_init_struct(ICM_20948_Device_t *pdev); // Initialize ICM_20948_Device_t
+
   // ICM_20948_Status_e ICM_20948_Startup( ICM_20948_Device_t* pdev ); // For the time being this performs a standardized startup routine
 
   ICM_20948_Status_e ICM_20948_link_serif(ICM_20948_Device_t *pdev, const ICM_20948_Serif_t *s); // Links a SERIF structure to the device


### PR DESCRIPTION
Resolves #71 
- Implement `ICM_20948_init_struct` function
- Initialize `_last_bank` to `4` (invalid bank number) 
- Update C++ constructor to use `ICM_20948_init_struct`
- Update the Example999