### PR TITLE
Update ICM_20948_C.h - add ifndef PORTDUINO to fix compilation

### DIFF
--- a/src/util/ICM_20948_C.h
+++ b/src/util/ICM_20948_C.h
@@ -22,7 +22,10 @@ extern "C"
 {
 #endif /* __cplusplus */
 
+// Portduino target uses system memcmp call, which conflicts with this
+#ifndef PORTDUINO
 extern int memcmp(const void *, const void *, size_t); // Avoid compiler warnings
+#endif
 
 // Define if the DMP will be supported
 // Note: you must have 14290/14301 Bytes of program memory available to store the DMP firmware!


### PR DESCRIPTION
This sensor code was failing to compile under the Portduino Native Linux target. Adding the ifndef fixes it, and shouldn't effect any other targets.