### PR TITLE
Another PORTDUINO fix

### DIFF
--- a/src/util/ICM_20948_C.h
+++ b/src/util/ICM_20948_C.h
@@ -23,7 +23,9 @@ extern "C"
 #endif /* __cplusplus */
 
 // Portduino target uses system memcmp call, which conflicts with this
-#ifndef PORTDUINO
+#ifdef PORTDUINO
+#include <string.h>
+#else
 extern int memcmp(const void *, const void *, size_t); // Avoid compiler warnings
 #endif
 


### PR DESCRIPTION
Sorry about the churn. My original patch works wonderfully on ARM machines like the Raspberry Pi, but for reasons I don't fully understand, it throws an error on X86_64 compilation. This further fix has been tested on both.